### PR TITLE
Update download.md

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -37,7 +37,6 @@ your downloads.
 - [Scnlog](https://scnlog.me/games) - Scene releases
 - [Gamdie](https://gamdie.com) - Indie games
 - [Appnetica](https://appnetica.com) - Indie games
-- [DigitalZone](https://digital-zone.xyz) - Indie games
 - [AtopGames](https://atopgames.com) - Indie games
 - [Leechinghell](http://www.leechinghell.pw) - LAN multiplayer games
 - [Wendy's Forum](https://wendysforum.net/index.php) - HOGs / Account
@@ -88,6 +87,7 @@ time due to file decompression.
 - :star2: [ElAmigos](https://elamigos.site) - Use GLOAD's or Ova Games'
   mirrors for free fast downloads.
 - :star2: [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
+- [TriahGames](https://triahgames.com)
 - [Xatab](https://byxatab.org)
 - [Chovka](http://rutor.info/browse/0/8/1642915/0), [2](https://repack.info)
 - [ScOOt3r Repacks](https://game-repack.site/scooter) - Moved to KaOsKrew in June 2024.

--- a/docs/download.md
+++ b/docs/download.md
@@ -37,6 +37,7 @@ your downloads.
 - [Scnlog](https://scnlog.me/games) - Scene releases
 - [Gamdie](https://gamdie.com) - Indie games
 - [Appnetica](https://appnetica.com) - Indie games
+- [DigitalZone](https://rentry.co/god_csrinru) - Indie games
 - [AtopGames](https://atopgames.com) - Indie games
 - [Leechinghell](http://www.leechinghell.pw) - LAN multiplayer games
 - [Wendy's Forum](https://wendysforum.net/index.php) - HOGs / Account

--- a/docs/download.md
+++ b/docs/download.md
@@ -74,6 +74,7 @@ piracy. Check the [VPNs section](/software#vpns) for more info.
 - :star2: [RuTracker](https://rutracker.org/forum/index.php?c=19) / [Torrent search](https://addons.mozilla.org/firefox/addon/rutracker_torrent_search)
   / [Translator](/useful#translator)
 - [Rutor](http://rutor.info/games) / [Translator](/useful#translator)
+- [Xatab](https://byxatab.org)
 - [Rustorka](https://rustorka.com/forum/index.php?c=6) /
   [Translator](/useful#translator)
 - [Mac Torrents](https://www.torrentmac.net/category/games) - macOS games & apps
@@ -89,7 +90,7 @@ time due to file decompression.
   mirrors for free fast downloads.
 - :star2: [KaOsKrew](https://kaoskrew.org/viewforum.php?f=13&sid=c2dac73979171b67f4c8b70c9c4c72fb)
 - [TriahGames](https://triahgames.com)
-- [Xatab](https://byxatab.org)
+- [Xatab](https://byxatab.org) - Most newer releases aren't repacks.
 - [Chovka](http://rutor.info/browse/0/8/1642915/0), [2](https://repack.info)
 - [ScOOt3r Repacks](https://game-repack.site/scooter) - Moved to KaOsKrew in June 2024.
 - [Masquerade Repacks](https://web.archive.org/web/20220616203326/https://masquerade.site) -


### PR DESCRIPTION
Removed DigitalZone because their website is no longer maintained or accessible.

Suggested replacing the link with either their Rentry page or their releases on Game Repack:
- https://rentry.co/god_csrinru
- https://game-repack.site/author/digitalzone
![firefox_UoO885pZ2t](https://github.com/user-attachments/assets/6cffa76d-e3e8-45df-97f3-db8a13c84462)

Also added Triah Games  it's an Indonesian repack site and their repacks are pretty solid.

One more suggestion: I think it might be better to move Xatab under the "Direct download site" section since most of their recent releases are portable torrent files. Not totally sure if it fits better under the torrent sites or Direct download site section though.
